### PR TITLE
WIP: Port to Nulls

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 DataStructures 0.4.5
 NamedTuples 3.0.2
-DataValues 0.0.2
+Nulls 0.1.0
 TableTraits 0.0.1

--- a/src/QueryOperators.jl
+++ b/src/QueryOperators.jl
@@ -1,7 +1,7 @@
 module QueryOperators
 
 using DataStructures
-using DataValues
+using Nulls
 using NamedTuples
 using TableTraits
 

--- a/src/enumerable/enumerable_count.jl
+++ b/src/enumerable/enumerable_count.jl
@@ -3,7 +3,7 @@ function _count(source::Enumerable, filter::Function, state)
     while !done(source, state)
         ret_val = next(source, state)
         state = ret_val[2]
-        if filter(ret_val[1])
+        if Nulls.coalesce(filter(ret_val[1]), false)
             count_val += 1
         end
     end
@@ -38,4 +38,13 @@ end
 
 macro count_internal(source)
     :(count($(esc(source))))
+end
+
+macro count(source, f)
+    q = Expr(:quote, f)
+    :(count(Query.query($(esc(source))), $(esc(f)), $(esc(q))))
+end
+
+macro count(source)
+    :(count(Query.query($(esc(source)))))
 end

--- a/src/enumerable/enumerable_defaultifempty.jl
+++ b/src/enumerable/enumerable_defaultifempty.jl
@@ -1,4 +1,4 @@
-immutable EnumerableDefaultIfEmpty{T,S} <: Enumerable
+struct EnumerableDefaultIfEmpty{T,S} <: Enumerable
     source::S
     default_value::T
 end
@@ -10,25 +10,24 @@ Base.eltype{T,S}(iter::Type{EnumerableDefaultIfEmpty{T,S}}) = T
 function default_if_empty{S}(source::S)
     T = eltype(source)
 
-    if T<:NamedTuple
-        if !all(i->i<:DataValue,T.parameters)
-            error("default_if_empty requires a default value if the source element is a NamedTuple and at least one of its fields is not a DataValue.")
+    if T <: NamedTuple
+        if !all(i->i >: Null, T.parameters)
+            error("default_if_empty requires a default value if the source element is a NamedTuple and at least one of its fields can't be `null`.")
         end
-        default_value = T([i() for i in T.parameters]...)
+        default_value = T([null for i in T.parameters]...)
     else
-        if !(T<:DataValue)
-            error("default_if_empty requires a default value if the source element is not a DataValue.")
+        if !(T >: Null)
+            error("default_if_empty requires a default value if the source element can't be `null`.")
         end
-        default_value = T()
+        default_value = null
     end
 
     return EnumerableDefaultIfEmpty{T,S}(source, default_value)
 end
 
-
 function default_if_empty{S,TD}(source::S, default_value::TD)
     T = eltype(source)
-    if T!=TD
+    if T != TD
         error("The default value must have the same type as the elements from the source.")
     end
     return EnumerableDefaultIfEmpty{T,S}(source, default_value)

--- a/src/enumerable/enumerable_where.jl
+++ b/src/enumerable/enumerable_where.jl
@@ -30,7 +30,7 @@ function Base.start{T,S,Q}(iter::EnumerableWhere{T,S,Q})
     s = start(iter.source)
     while !done(iter.source, s)
         v,t = next(iter.source, s)
-        if iter.filter(v)
+        if Nulls.coalesce(iter.filter(v), false)
             return EnumerableWhereState(false, Nullable(v), t)
         end
         s = t
@@ -47,7 +47,7 @@ function Base.next{T,S,Q}(iter::EnumerableWhere{T,S,Q}, state)
         temp = next(iter.source,s)
         w = temp[1]
         t = temp[2]
-        if iter.filter(w)::Bool
+        if Nulls.coalesce(iter.filter(w), false)::Bool
             temp2 = Nullable(w)
             new_state = EnumerableWhereState(false, temp2, t)
             return v, new_state


### PR DESCRIPTION
Companion PR to [Query](https://github.com/davidanthoff/Query.jl/pull/155).

Not a lot of changes needed here, just the `default_if_empty` update and a few cases boolean checks where we want to make sure we account for Nulls behavior of `null == true = null`. This should allow preserving existing semantics in Query/QueryOperators as they worked w/ DataValues.