### PR TITLE
RFC/WIP: preserve the type of the source upon collect(Enumerable)

### DIFF
--- a/src/enumerable/enumerable.jl
+++ b/src/enumerable/enumerable.jl
@@ -1,3 +1,6 @@
-abstract type Enumerable end
+abstract type Enumerable{T} end
+
+Base.eltype(::Type{<:Enumerable{T}}) where T = T
+Base.eltype(::Enumerable{T}) where T = T
 
 Base.iteratorsize{T<:Enumerable}(::Type{T}) = Base.SizeUnknown()

--- a/src/enumerable/enumerable.jl
+++ b/src/enumerable/enumerable.jl
@@ -1,6 +1,15 @@
+# enumerable that returns elements of type T
 abstract type Enumerable{T} end
 
 Base.eltype(::Type{<:Enumerable{T}}) where T = T
 Base.eltype(::Enumerable{T}) where T = T
 
 Base.iteratorsize{T<:Enumerable}(::Type{T}) = Base.SizeUnknown()
+
+# enumerable that feeds from simple source of type S and doesn't transform its elements
+abstract type SimpleSourceEnumerable{T, S} <: Enumerable{T} end
+
+source(iter::SimpleSourceEnumerable{T, S}) where {T,S} = iter.source
+
+sourcetype(iter::SimpleSourceEnumerable{T, S}) where {T,S} = S
+sourcetype(iter::Type{<:SimpleSourceEnumerable{T, S}}) where {T,S} = S

--- a/src/enumerable/enumerable_defaultifempty.jl
+++ b/src/enumerable/enumerable_defaultifempty.jl
@@ -1,11 +1,7 @@
-immutable EnumerableDefaultIfEmpty{T,S} <: Enumerable
+immutable EnumerableDefaultIfEmpty{T,S} <: Enumerable{T}
     source::S
     default_value::T
 end
-
-Base.eltype{T,S}(iter::EnumerableDefaultIfEmpty{T,S}) = T
-
-Base.eltype{T,S}(iter::Type{EnumerableDefaultIfEmpty{T,S}}) = T
 
 function default_if_empty{S}(source::S)
     T = eltype(source)

--- a/src/enumerable/enumerable_defaultifempty.jl
+++ b/src/enumerable/enumerable_defaultifempty.jl
@@ -1,4 +1,4 @@
-immutable EnumerableDefaultIfEmpty{T,S} <: Enumerable{T}
+immutable EnumerableDefaultIfEmpty{T,S} <: SimpleSourceEnumerable{T,S}
     source::S
     default_value::T
 end

--- a/src/enumerable/enumerable_groupby.jl
+++ b/src/enumerable/enumerable_groupby.jl
@@ -1,4 +1,4 @@
-immutable EnumerableGroupBySimple{T,TKey,TS,SO,ES<:Function} <: Enumerable
+immutable EnumerableGroupBySimple{T,TKey,TS,SO,ES<:Function} <: Enumerable{T}
     source::SO
     elementSelector::ES
 end
@@ -11,10 +11,6 @@ end
 Base.size{TKey,T}(A::Grouping{TKey,T}) = size(A.elements)
 Base.getindex{TKey,T}(A::Grouping{TKey,T},i) = A.elements[i]
 Base.length{TKey,T}(A::Grouping{TKey,T}) = length(A.elements)
-
-Base.eltype{T,TKey,TS,SO,ES}(iter::EnumerableGroupBySimple{T,TKey,TS,SO,ES}) = T
-
-Base.eltype{T,TKey,TS,SO,ES}(iter::Type{EnumerableGroupBySimple{T,TKey,TS,SO,ES}}) = T
 
 function group_by(source::Enumerable, f_elementSelector::Function, elementSelector::Expr)
     TS = eltype(source)
@@ -54,15 +50,11 @@ function Base.done{T,TKey,TS,SO,ES}(iter::EnumerableGroupBySimple{T,TKey,TS,SO,E
     return curr_index > length(results)
 end
 
-immutable EnumerableGroupBy{T,TKey,TR,SO,ES<:Function,RS<:Function} <: Enumerable
+immutable EnumerableGroupBy{T,TKey,TR,SO,ES<:Function,RS<:Function} <: Enumerable{T}
     source::SO
     elementSelector::ES
     resultSelector::RS
 end
-
-Base.eltype{T,TKey,TR,SO,ES}(iter::EnumerableGroupBy{T,TKey,TR,SO,ES}) = T
-
-Base.eltype{T,TKey,TR,SO,ES}(iter::Type{EnumerableGroupBy{T,TKey,TR,SO,ES}}) = T
 
 function group_by(source::Enumerable, f_elementSelector::Function, elementSelector::Expr, f_resultSelector::Function, resultSelector::Expr)
     TS = eltype(source)

--- a/src/enumerable/enumerable_groupjoin.jl
+++ b/src/enumerable/enumerable_groupjoin.jl
@@ -1,14 +1,10 @@
-immutable EnumerableGroupJoin{T,TKey,TI,SO,SI,OKS<:Function,IKS<:Function,RS<:Function} <: Enumerable
+immutable EnumerableGroupJoin{T,TKey,TI,SO,SI,OKS<:Function,IKS<:Function,RS<:Function} <: Enumerable{T}
     outer::SO
     inner::SI
     outerKeySelector::OKS
     innerKeySelector::IKS
     resultSelector::RS
 end
-
-Base.eltype{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}(iter::EnumerableGroupJoin{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}) = T
-
-Base.eltype{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}(iter::Type{EnumerableGroupJoin{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}}) = T
 
 function group_join(outer::Enumerable, inner::Enumerable, f_outerKeySelector::Function, outerKeySelector::Expr, f_innerKeySelector::Function, innerKeySelector::Expr, f_resultSelector::Function, resultSelector::Expr)
     TO = eltype(outer)

--- a/src/enumerable/enumerable_join.jl
+++ b/src/enumerable/enumerable_join.jl
@@ -1,14 +1,10 @@
-immutable EnumerableJoin{T,TKey,TI,SO,SI,OKS<:Function,IKS<:Function,RS<:Function} <: Enumerable
+immutable EnumerableJoin{T,TKey,TI,SO,SI,OKS<:Function,IKS<:Function,RS<:Function} <: Enumerable{T}
     outer::SO
     inner::SI
     outerKeySelector::OKS
     innerKeySelector::IKS
     resultSelector::RS
 end
-
-Base.eltype{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}(iter::EnumerableJoin{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}) = T
-
-Base.eltype{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}(iter::Type{EnumerableJoin{T,TKeyOuter,TI,SO,SI,OKS,IKS,RS}}) = T
 
 function join(outer::Enumerable, inner::Enumerable, f_outerKeySelector::Function, outerKeySelector::Expr, f_innerKeySelector::Function, innerKeySelector::Expr, f_resultSelector::Function, resultSelector::Expr)
     TO = eltype(outer)

--- a/src/enumerable/enumerable_orderby.jl
+++ b/src/enumerable/enumerable_orderby.jl
@@ -1,4 +1,4 @@
-immutable EnumerableOrderby{T,S,KS<:Function,TKS} <: Enumerable{T}
+immutable EnumerableOrderby{T,S,KS<:Function,TKS} <: SimpleSourceEnumerable{T,S}
     source::S
     keySelector::KS
     descending::Bool
@@ -54,7 +54,7 @@ end
 
 Base.done{T,S,KS,TKS}(f::EnumerableOrderby{T,S,KS,TKS}, state) = state[2] > length(state[1])
 
-immutable EnumerableThenBy{T,S,KS<:Function,TKS} <: Enumerable{T}
+immutable EnumerableThenBy{T,S,KS<:Function,TKS} <: SimpleSourceEnumerable{T,S}
     source::S
     keySelector::KS
     descending::Bool

--- a/src/enumerable/enumerable_orderby.jl
+++ b/src/enumerable/enumerable_orderby.jl
@@ -1,14 +1,10 @@
-immutable EnumerableOrderby{T,S,KS<:Function,TKS} <: Enumerable
+immutable EnumerableOrderby{T,S,KS<:Function,TKS} <: Enumerable{T}
     source::S
     keySelector::KS
     descending::Bool
 end
 
 Base.iteratorsize{T,S,KS,TKS}(::Type{EnumerableOrderby{T,S,KS,TKS}}) = Base.iteratorsize(S)
-
-Base.eltype{T,S,KS,TKS}(iter::EnumerableOrderby{T,S,KS,TKS}) = T
-
-Base.eltype{T,S,KS,TKS}(iter::Type{EnumerableOrderby{T,S,KS,TKS}}) = T
 
 Base.length{T,S,KS,TKS}(iter::EnumerableOrderby{T,S,KS,TKS}) = length(iter.source)
 
@@ -58,15 +54,11 @@ end
 
 Base.done{T,S,KS,TKS}(f::EnumerableOrderby{T,S,KS,TKS}, state) = state[2] > length(state[1])
 
-immutable EnumerableThenBy{T,S,KS<:Function,TKS} <: Enumerable
+immutable EnumerableThenBy{T,S,KS<:Function,TKS} <: Enumerable{T}
     source::S
     keySelector::KS
     descending::Bool
 end
-
-Base.eltype{T,S,KS,TKS}(iter::EnumerableThenBy{T,S,KS,TKS}) = T
-
-Base.eltype{T,S,KS,TKS}(iter::Type{EnumerableThenBy{T,S,KS,TKS}}) = T
 
 Base.length{T,S,KS,TKS}(iter::EnumerableThenBy{T,S,KS,TKS}) = length(iter.source)
 

--- a/src/enumerable/enumerable_select.jl
+++ b/src/enumerable/enumerable_select.jl
@@ -1,13 +1,9 @@
-immutable EnumerableSelect{T, S, Q<:Function} <: Enumerable
+immutable EnumerableSelect{T, S, Q<:Function} <: Enumerable{T}
     source::S
     f::Q
 end
 
 Base.iteratorsize{T,S,Q}(::Type{EnumerableSelect{T,S,Q}}) = Base.iteratorsize(S)
-
-Base.eltype{T,S,Q}(iter::EnumerableSelect{T,S,Q}) = T
-
-Base.eltype{T,S,Q}(iter::Type{EnumerableSelect{T,S,Q}}) = T
 
 Base.length{T,S,Q}(iter::EnumerableSelect{T,S,Q}) = length(iter.source)
 

--- a/src/enumerable/enumerable_selectmany.jl
+++ b/src/enumerable/enumerable_selectmany.jl
@@ -1,12 +1,8 @@
-immutable EnumerableSelectMany{T,SO,CS<:Function,RS<:Function} <: Enumerable
+immutable EnumerableSelectMany{T,SO,CS<:Function,RS<:Function} <: Enumerable{T}
     source::SO
     collectionSelector::CS
     resultSelector::RS
 end
-
-Base.eltype{T,SO,CS,RS}(iter::EnumerableSelectMany{T,SO,CS,RS}) = T
-
-Base.eltype{T,SO,CS,RS}(iter::Type{EnumerableSelectMany{T,SO,CS,RS}}) = T
 
 # TODO Make sure this is actually correct. We might have to be more selective,
 # i.e. only scan arguments for certain types of expression etc.

--- a/src/enumerable/enumerable_where.jl
+++ b/src/enumerable/enumerable_where.jl
@@ -1,5 +1,5 @@
 # T is the type of the elements produced by this iterator
-immutable EnumerableWhere{T,S,Q<:Function} <: Enumerable{T}
+immutable EnumerableWhere{T,S,Q<:Function} <: SimpleSourceEnumerable{T, S}
     source::S
     filter::Q
 end

--- a/src/enumerable/enumerable_where.jl
+++ b/src/enumerable/enumerable_where.jl
@@ -1,12 +1,8 @@
 # T is the type of the elements produced by this iterator
-immutable EnumerableWhere{T,S,Q<:Function} <: Enumerable
+immutable EnumerableWhere{T,S,Q<:Function} <: Enumerable{T}
     source::S
     filter::Q
 end
-
-Base.eltype{T,S,Q}(iter::EnumerableWhere{T,S,Q}) = T
-
-Base.eltype{T,S,Q}(iter::Type{EnumerableWhere{T,S,Q}}) = T
 
 immutable EnumerableWhereState{T,S}
     done::Bool

--- a/src/sink_array.jl
+++ b/src/sink_array.jl
@@ -1,10 +1,17 @@
+init_sink(enumerable::Enumerable) = Vector{eltype(enumerable)}()
+
+# preserve AbstractArray subtype when collecting
+# allows collecting CategoricalValue into CategoricalArray
+init_sink(enumerable::SimpleSourceEnumerable{T,<:AbstractVector{T}}) where T =
+    similar(source(enumerable), 0)
+
+# recurse to get to the root source
+init_sink(enumerable::SimpleSourceEnumerable{T,<:SimpleSourceEnumerable{T}}) where T =
+    init_sink(source(enumerable))
+
 function Base.collect(enumerable::Enumerable)
-    T = eltype(enumerable)
-    ret = Array{T}(0)
-    for i in enumerable
-        push!(ret, i)
-    end
-    return ret
+    ret = init_sink(enumerable)
+    append!(ret, enumerable)
 end
 
 function Base.collect{TS,Provider}(source::Queryable{TS,Provider})

--- a/src/source_iterable.jl
+++ b/src/source_iterable.jl
@@ -1,4 +1,4 @@
-immutable EnumerableIterable{T,S} <: Enumerable{T}
+immutable EnumerableIterable{T,S} <: SimpleSourceEnumerable{T,S}
     source::S
 end
 

--- a/src/source_iterable.jl
+++ b/src/source_iterable.jl
@@ -1,4 +1,4 @@
-immutable EnumerableIterable{T,S} <: Enumerable
+immutable EnumerableIterable{T,S} <: Enumerable{T}
     source::S
 end
 
@@ -14,10 +14,6 @@ function query(source)
 end
 
 Base.iteratorsize{T,S}(::Type{EnumerableIterable{T,S}}) = Base.iteratorsize(S)
-
-Base.eltype{T,S}(iter::EnumerableIterable{T,S}) = T
-
-Base.eltype{T,S}(iter::Type{EnumerableIterable{T,S}}) = T
 
 Base.length{T,S}(iter::EnumerableIterable{T,S}) = length(iter.source)
 


### PR DESCRIPTION
No user-code workaround for davidanthoff/Query.jl#157 came to my mind, so I decided to propose a fix.

The first commit just adds `T` param to the `Enumerable`, which allows reducing `eltype()` redundancy. I think it's a good change overall.

The 2nd commit introduces `SimpleSourceEnumerable{T,S}`, which is a type of enumerable that have a single source and doesn't transform elements, e.g. "where" and "orderby".
The 3rd commits actually allows `SimpleSourceEnumerable` to preserve the type of the `AbstractArray` source upon `collect()`, which covers the `CategoricalArray` case without requiring CategoricalArrays dependency.

Actually, it would make sense to try to preserve the source type for the other enumerables if the sink is of the same/similar type as the source(s).
Even if the elements are transformed, but the result is `CategoricalValue`, it would make sense to collect them into `CategoricalArray`.
But that would require more general design or package dependency decisions.