### PR TITLE
Make default_if_empty work again

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.7
 DataStructures 0.11.0
 IteratorInterfaceExtensions 0.1.1
 TableShowUtils 0.1.1
+DataValues 0.4.5

--- a/src/QueryOperators.jl
+++ b/src/QueryOperators.jl
@@ -3,6 +3,7 @@ module QueryOperators
 using DataStructures
 using IteratorInterfaceExtensions
 using TableShowUtils
+import DataValues
 
 export Grouping, key
 

--- a/src/enumerable/enumerable_defaultifempty.jl
+++ b/src/enumerable/enumerable_defaultifempty.jl
@@ -5,16 +5,28 @@ end
 
 Base.eltype(iter::Type{EnumerableDefaultIfEmpty{T,S}}) where {T,S} = T
 
-function default_if_empty(source::S) where {S}
-    T = eltype(source)
+_default_value_expr(::Type{T}) where {T} = :( DataValues.DataValue{$T}() )
 
-    if T<:NamedTuple
-        default_value = T(([fieldtype(T,i)() for i in 1:length(fieldnames(T))]...,))
-    else
-        default_value = T()
+_default_value_expr(::Type{T}) where {T<:DataValues.DataValue} = :( $T() )
+
+function _default_value_expr(::Type{T}) where {T<:NamedTuple}
+    return :( NamedTuple{$(fieldnames(T))}( ($( (_default_value_expr(fieldtype(T,i)) for i in 1:length(fieldnames(T)))...   ),)) )
+end
+
+@generated function default_if_empty(source::S) where {S}
+    T_source = eltype(source)
+
+    default_value_expr = _default_value_expr(T_source)
+
+    q = quote
+        default_value = $default_value_expr
+
+        T = typeof(default_value)
+
+        return EnumerableDefaultIfEmpty{T,$S}(source, default_value)
     end
 
-    return EnumerableDefaultIfEmpty{T,S}(source, default_value)
+    return q
 end
 
 
@@ -32,14 +44,17 @@ function Base.iterate(iter::EnumerableDefaultIfEmpty{T,S}) where {T,S}
     if s===nothing
         return iter.default_value, nothing
     else
-        return s
+        return convert(T,s[1]), s[2]
     end
 end
 
 function Base.iterate(iter::EnumerableDefaultIfEmpty{T,S}, state) where {T,S}
-    if state===nothing
+    state===nothing && return nothing
+
+    s = iterate(iter.source, state)
+    if s===nothing
         return nothing
     else
-        return iterate(iter.source, state)
+        return convert(T, s[1]), s[2]
     end
 end


### PR DESCRIPTION
The old version only worked if the source DataFrame had missable
columns. This now works even if that is not the case.