### PR TITLE
Fix expr_contains_ref_to for numeric expressions

### DIFF
--- a/src/enumerable/enumerable_mapmany.jl
+++ b/src/enumerable/enumerable_mapmany.jl
@@ -36,6 +36,8 @@ function expr_contains_ref_to(expr::Function, var_name::Symbol)
     return false
 end
 
+expr_contains_ref_to(::Number, ::Symbol) = false
+
 function mapmany(source::Enumerable, f_collectionSelector::Function, collectionSelector::Expr, f_resultSelector::Function, resultSelector::Expr)
     TS = eltype(source)
     # First detect whether the collectionSelector return value depends at all


### PR DESCRIPTION
Now things like @mapmany(1:_, __) work