### PR TITLE
Change IteratorSize on EnumerableMap to just pass through from underl…

### DIFF
--- a/src/enumerable/enumerable.jl
+++ b/src/enumerable/enumerable.jl
@@ -1,3 +1,5 @@
 abstract type Enumerable end
 
 Base.IteratorSize(::Type{T}) where {T <: Enumerable} = Base.SizeUnknown()
+
+haslength(S) = Base.IteratorSize(S) isa Union{Base.HasLength, Base.HasShape} ? Base.HasLength() : Base.IteratorSize(S)

--- a/src/enumerable/enumerable_map.jl
+++ b/src/enumerable/enumerable_map.jl
@@ -3,7 +3,7 @@ struct EnumerableMap{T, S, Q<:Function} <: Enumerable
     f::Q
 end
 
-Base.IteratorSize(::Type{EnumerableMap{T,S,Q}}) where {T,S,Q} = Base.IteratorSize(S)
+Base.IteratorSize(::Type{EnumerableMap{T,S,Q}}) where {T,S,Q} = haslength(S)
 
 Base.eltype(iter::Type{EnumerableMap{T,S,Q}}) where {T,S,Q} = T
 

--- a/src/enumerable/enumerable_map.jl
+++ b/src/enumerable/enumerable_map.jl
@@ -3,7 +3,7 @@ struct EnumerableMap{T, S, Q<:Function} <: Enumerable
     f::Q
 end
 
-Base.IteratorSize(::Type{EnumerableMap{T,S,Q}}) where {T,S,Q} = !in(Base.IteratorSize(S), (Base.IsInfinite(), Base.SizeUnknown())) ? Base.HasLength() : Base.IteratorSize(S)
+Base.IteratorSize(::Type{EnumerableMap{T,S,Q}}) where {T,S,Q} = Base.IteratorSize(S)
 
 Base.eltype(iter::Type{EnumerableMap{T,S,Q}}) where {T,S,Q} = T
 

--- a/src/enumerable/enumerable_orderby.jl
+++ b/src/enumerable/enumerable_orderby.jl
@@ -4,7 +4,7 @@ struct EnumerableOrderby{T,S,KS<:Function,TKS} <: Enumerable
     descending::Bool
 end
 
-Base.IteratorSize(::Type{EnumerableOrderby{T,S,KS,TKS}}) where {T,S,KS,TKS} = (Base.IteratorSize(S) isa Base.HasLength || Base.IteratorSize(S) isa Base.HasShape) ? Base.HasLength() : Base.IteratorSize(S)
+Base.IteratorSize(::Type{EnumerableOrderby{T,S,KS,TKS}}) where {T,S,KS,TKS} = haslength(S)
 
 Base.eltype(::Type{EnumerableOrderby{T,S,KS,TKS}}) where {T,S,KS,TKS} = T
 

--- a/src/enumerable/enumerable_take.jl
+++ b/src/enumerable/enumerable_take.jl
@@ -9,7 +9,7 @@ function take(source::Enumerable, n::Integer)
     return EnumerableTake{T,S}(source, Int(n))
 end
 
-Base.IteratorSize(::Type{EnumerableTake{T,S}}) where {T,S} = (Base.IteratorSize(S) isa Base.HasLength || Base.IteratorSize(S) isa Base.HasShape) ? Base.HasLength() : Base.SizeUnknown()
+Base.IteratorSize(::Type{EnumerableTake{T,S}}) where {T,S} = haslength(S)
 
 Base.eltype(::Type{EnumerableTake{T,S}}) where {T,S} = T
 

--- a/src/source_iterable.jl
+++ b/src/source_iterable.jl
@@ -13,7 +13,7 @@ function query(source)
     return source_enumerable
 end
 
-Base.IteratorSize(::Type{EnumerableIterable{T,S}}) where {T,S} = Base.IteratorSize(S) isa Base.HasShape ? Base.HasLength() : Base.IteratorSize(S)
+Base.IteratorSize(::Type{EnumerableIterable{T,S}}) where {T,S} = haslength(S)
 
 Base.eltype(::Type{EnumerableIterable{T,S}}) where {T,S} = T
 


### PR DESCRIPTION
…ying iterator

In a benchmark I'm running this made about a 10% impact on performance; the problem is that the current code is non-compile-time inferrable, so it involved doing runtime dispatch on a trait meant to be compile-time friendly.