### PR TITLE
Add the summarize operator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# QueryOperators.jl v1.1.0 Release Notes
+* Add the summarize operator for grouped and whole-table aggregation
+
 # QueryOperators.jl v1.0.0 Release Notes
 * Add the pivot_wider and pivot_longer operators
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QueryOperators"
 uuid = "2aef5ad7-51ca-5a8f-8e88-e75cf067b44b"
-version = "1.0.2-DEV"
+version = "1.1.0-DEV"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/QueryOperators.jl
+++ b/src/QueryOperators.jl
@@ -24,6 +24,7 @@ include("enumerable/enumerable_take.jl")
 include("enumerable/enumerable_drop.jl")
 include("enumerable/enumerable_unique.jl")
 include("enumerable/enumerable_pivot.jl")
+include("enumerable/enumerable_summarize.jl")
 include("enumerable/show.jl")
 
 include("source_iterable.jl")

--- a/src/enumerable/enumerable_summarize.jl
+++ b/src/enumerable/enumerable_summarize.jl
@@ -1,0 +1,44 @@
+# Internal marker used as the key of the keyless Grouping that the ungrouped
+# summarize path wraps its source in.
+struct _SummarizeUngroupedKey end
+
+_key_namedtuple(k::NamedTuple) = k                        # multi-column grouping key: splat fields in
+_key_namedtuple(::_SummarizeUngroupedKey) = NamedTuple()  # ungrouped: no key columns
+_key_namedtuple(k) = (key = k,)                           # scalar key: column named `key`
+
+# Lazy one-element enumerable used by the ungrouped summarize path: on first
+# iterate it collects the source rows, wraps them in a keyless Grouping (so
+# that column access on the group works exactly as in the grouped path) and
+# yields the single aggregated row.
+struct EnumerableSummarizeAll{T,S,Q<:Function} <: Enumerable
+    source::S
+    f::Q
+end
+
+Base.eltype(::Type{EnumerableSummarizeAll{T,S,Q}}) where {T,S,Q} = T
+Base.IteratorSize(::Type{<:EnumerableSummarizeAll}) = Base.HasLength()
+Base.length(::EnumerableSummarizeAll) = 1
+
+function Base.iterate(iter::EnumerableSummarizeAll{T,S,Q}) where {T,S,Q}
+    TS = eltype(iter.source)
+    elements = Base.collect(TS, iter.source)
+    g = Grouping{_SummarizeUngroupedKey,TS}(_SummarizeUngroupedKey(), elements)
+    return iter.f(g), nothing
+end
+
+Base.iterate(::EnumerableSummarizeAll, state) = nothing
+
+summarize(source::Enumerable, f::Function, f_expr::Expr) =
+    _summarize(source, eltype(source), f, f_expr)
+
+# Grouped input: one output row per group, as a lazy map over the groups.
+_summarize(source, ::Type{<:Grouping}, f::Function, f_expr::Expr) =
+    map(source, f, f_expr)
+
+# Ungrouped input: the whole source is treated as a single keyless group,
+# producing a stream of exactly one row.
+function _summarize(source, ::Type{TS}, f::Function, f_expr::Expr) where {TS}
+    TG = Grouping{_SummarizeUngroupedKey,TS}
+    T = Base._return_type(f, Tuple{TG})
+    return EnumerableSummarizeAll{T,typeof(source),typeof(f)}(source, f)
+end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -127,3 +127,5 @@ end
 function pivot_longer end
 
 function pivot_wider end
+
+function summarize end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using TestItemRunner
 
 include("test_core.jl")
 include("test_enumerable_unique.jl")
+include("test_enumerable_summarize.jl")
 include("test_namedtupleutilities.jl")
 include("test_pivot.jl")
 

--- a/test/test_enumerable_summarize.jl
+++ b/test/test_enumerable_summarize.jl
@@ -1,0 +1,47 @@
+@testitem "summarize grouped" begin
+    using Statistics
+
+    source = [(k=1, x=1.0), (k=1, x=2.0), (k=2, x=4.0)]
+    grouped = QueryOperators.@groupby_simple(QueryOperators.query(source), i->i.k)
+
+    f = g -> merge(QueryOperators._key_namedtuple(QueryOperators.key(g)),
+                   (m = mean(g.x), n = length(g)))
+    r = collect(QueryOperators.summarize(grouped, f, :(g -> nothing)))
+
+    @test r == [(key=1, m=1.5, n=2), (key=2, m=4.0, n=1)]
+    @test isconcretetype(eltype(r))
+
+    # multi-column key: fields splat in as columns
+    source2 = [(a=1, b=1, x=1.0), (a=1, b=1, x=3.0), (a=2, b=1, x=5.0)]
+    grouped2 = QueryOperators.@groupby_simple(QueryOperators.query(source2), i->(a=i.a, b=i.b))
+    f2 = g -> merge(QueryOperators._key_namedtuple(QueryOperators.key(g)), (m = mean(g.x),))
+    r2 = collect(QueryOperators.summarize(grouped2, f2, :(g -> nothing)))
+
+    @test r2 == [(a=1, b=1, m=2.0), (a=2, b=1, m=5.0)]
+end
+
+@testitem "summarize ungrouped" begin
+    using Statistics
+
+    source = [(k=1, x=1.0), (k=1, x=2.0), (k=2, x=4.0)]
+    enum = QueryOperators.query(source)
+
+    f = g -> merge(QueryOperators._key_namedtuple(QueryOperators.key(g)),
+                   (m = mean(g.x), n = length(g)))
+    op = QueryOperators.summarize(enum, f, :(g -> nothing))
+
+    @test Base.IteratorSize(typeof(op)) == Base.HasLength()
+    @test length(op) == 1
+    @test isconcretetype(eltype(op))
+
+    r = collect(op)
+    @test r == [(m=7/3, n=3)]
+
+    # the keyless internal Grouping contributes no key columns
+    @test !haskey(r[1], :key)
+
+    # empty source: aggregates see an empty collection
+    empty_enum = QueryOperators.query(NamedTuple{(:x,),Tuple{Float64}}[])
+    fe = g -> (n = length(g),)
+    @test collect(QueryOperators.summarize(empty_enum, fe, :(g -> nothing))) == [(n=0,)]
+end


### PR DESCRIPTION
Adds `QueryOperators.summarize(source::Enumerable, f, f_expr)` — the operator layer for the new `@summarize` macro in queryverse/Query.jl#356, moved here so it lives alongside the other enumerables and so the generic function is open for backend methods (`QueryOperators.summarize(::Queryable, ...)` can be overloaded by plan-capturing backends later).

## What it does

- **Grouped input** (`eltype(source) <: Grouping`): lowers to a lazy `map` over the groups — one output row per group.
- **Ungrouped input**: the whole source is treated as a single keyless group via the new lazy one-row `EnumerableSummarizeAll`, which on first iterate collects the rows into a `Grouping` keyed by the internal `_SummarizeUngroupedKey` sentinel, so column access on the group works identically in both paths.
- `_key_namedtuple` normalizes grouping keys into result columns: NamedTuple keys splat into one column per field, a scalar key becomes a column named `key`, and the keyless sentinel contributes no columns. Query.jl's `@summarize` merges this in front of the aggregate columns.
- A `function summarize end` stub sits in `operators.jl` next to `pivot_longer`/`pivot_wider`.

Both paths produce a concrete inferred row eltype (verified with `isconcretetype` tests), since downstream operators rely on `Base._return_type`.

## Notes

- Version bumped to 1.1.0-DEV; queryverse/Query.jl#356 sets `QueryOperators = "1.1"` compat, so this needs to be merged and registered before that PR's CI can go green.
- New testitems cover the grouped path (scalar and multi-column keys), the ungrouped path (`HasLength`, length 1, no key columns, empty source), and eltype concreteness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)